### PR TITLE
Add problem selection step after pairing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -131,6 +131,69 @@ body {
     }
   }
 
+  &.page-problem-select {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+
+    main {
+      width: min(600px, 90vw);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      text-align: center;
+      background: #ffffff;
+      padding: 3rem 2.5rem;
+      border-radius: 1.5rem;
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+    }
+
+    .code-display {
+      font-size: 1.4rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      margin: 0;
+    }
+
+    .select-instruction {
+      margin: 0;
+      color: #555;
+    }
+
+    .problem-select {
+      width: 100%;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 1rem;
+
+      button {
+        font-size: 1.2rem;
+        padding: 1rem 0;
+        border-radius: 1rem;
+        border: none;
+        background: #355cdd;
+        color: #fff;
+        font-weight: 700;
+        cursor: pointer;
+        box-shadow: 0 4px 14px rgba(53, 92, 221, 0.25);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+        &:hover,
+        &:focus-visible {
+          transform: translateY(-2px);
+          box-shadow: 0 6px 18px rgba(53, 92, 221, 0.35);
+        }
+
+        &:active {
+          transform: translateY(1px);
+          box-shadow: 0 3px 10px rgba(53, 92, 221, 0.3);
+        }
+      }
+    }
+  }
+
   &.page-mobile-controller {
     display: flex;
     flex-direction: column;

--- a/js/mobile-problem.js
+++ b/js/mobile-problem.js
@@ -1,0 +1,32 @@
+(() => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code') || '';
+  const codeDisplay = document.querySelector('[data-code-display]');
+  const buttons = document.querySelectorAll('[data-problem]');
+
+  if (codeDisplay) {
+    codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
+  }
+
+  const destinations = {
+    '1': 'mobile-next.html',
+    '2': 'mobile-next.html',
+    '3': 'mobile-next.html',
+    '4': 'mobile-next.html',
+    '5': 'mobile-next.html'
+  };
+
+  const goToProblem = (problem) => {
+    const dest = destinations[problem] || destinations['1'];
+    if (!dest) return;
+    const url = code ? `${dest}?code=${encodeURIComponent(code)}` : dest;
+    window.location.href = url;
+  };
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const { problem } = button.dataset;
+      goToProblem(problem);
+    });
+  });
+})();

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -54,20 +54,20 @@
   socket.on('status', ({ role, code } = {}) => {
     if (role === 'mobile') {
       const c = code || currentCode;
-      location.href = `mobile-next.html?code=${encodeURIComponent(c)}`;
+      location.href = `mobile-problem.html?code=${encodeURIComponent(c)}`;
     }
   });
 
   // 新実装: PCとスマホの“同時遷移”合図
   socket.on('paired', ({ code } = {}) => {
     const c = code || currentCode;
-    location.href = `mobile-next.html?code=${encodeURIComponent(c)}`;
+    location.href = `mobile-problem.html?code=${encodeURIComponent(c)}`;
   });
 
   // 互換フォールバック: “部屋の人数更新”で2人以上になったら遷移
   socket.on('memberUpdate', (info = {}) => {
     if (info.type === 'join' && typeof info.count === 'number' && info.count >= 2) {
-      location.href = `mobile-next.html?code=${encodeURIComponent(currentCode)}`;
+      location.href = `mobile-problem.html?code=${encodeURIComponent(currentCode)}`;
     }
   });
 

--- a/js/pc-problem.js
+++ b/js/pc-problem.js
@@ -1,0 +1,32 @@
+(() => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code') || '';
+  const codeDisplay = document.querySelector('[data-code-display]');
+  const buttons = document.querySelectorAll('[data-problem]');
+
+  if (codeDisplay) {
+    codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
+  }
+
+  const destinations = {
+    '1': 'pc-next.html',
+    '2': 'pc-next.html',
+    '3': 'pc-next.html',
+    '4': 'pc-next.html',
+    '5': 'pc-next.html'
+  };
+
+  const goToProblem = (problem) => {
+    const dest = destinations[problem] || destinations['1'];
+    if (!dest) return;
+    const url = code ? `${dest}?code=${encodeURIComponent(code)}` : dest;
+    window.location.href = url;
+  };
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const { problem } = button.dataset;
+      goToProblem(problem);
+    });
+  });
+})();

--- a/js/pc.js
+++ b/js/pc.js
@@ -31,14 +31,14 @@
   // 🔴 スマホが同じコードで入室した合図（同時遷移）
   socket.on('paired', ({ code } = {}) => {
     const c = code || currentCode || '';
-    location.href = `pc-next.html?code=${encodeURIComponent(c)}`;
+    location.href = `pc-problem.html?code=${encodeURIComponent(c)}`;
   });
 
   // 互換フォールバック：メンバー数イベントで2人以上になったら遷移
   socket.on('memberUpdate', (info = {}) => {
     if (info.type === 'join' && typeof info.count === 'number' && info.count >= 2) {
       const c = currentCode || '';
-      location.href = `pc-next.html?code=${encodeURIComponent(c)}`;
+      location.href = `pc-problem.html?code=${encodeURIComponent(c)}`;
     }
   });
 

--- a/mobile-problem.html
+++ b/mobile-problem.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>スマホ - 問題選択</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script src="js/mobile-problem.js" defer></script>
+  </head>
+  <body class="page page-problem-select page-mobile-problem">
+    <main>
+      <h1>問題を選択</h1>
+      <p class="code-display" data-code-display></p>
+      <p class="select-instruction">挑戦する問題番号を選んでください。</p>
+      <div class="problem-select">
+        <button type="button" data-problem="1">問題1</button>
+        <button type="button" data-problem="2">問題2</button>
+        <button type="button" data-problem="3">問題3</button>
+        <button type="button" data-problem="4">問題4</button>
+        <button type="button" data-problem="5">問題5</button>
+      </div>
+    </main>
+  </body>
+</html>

--- a/pc-problem.html
+++ b/pc-problem.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PC - 問題選択</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script src="js/pc-problem.js" defer></script>
+  </head>
+  <body class="page page-problem-select page-pc-problem">
+    <main>
+      <h1>問題を選択</h1>
+      <p class="code-display" data-code-display></p>
+      <p class="select-instruction">解きたい問題番号を選択してください。</p>
+      <div class="problem-select">
+        <button type="button" data-problem="1">問題1</button>
+        <button type="button" data-problem="2">問題2</button>
+        <button type="button" data-problem="3">問題3</button>
+        <button type="button" data-problem="4">問題4</button>
+        <button type="button" data-problem="5">問題5</button>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated problem selection pages for both PC and mobile after a successful pairing
- update the connection flow to redirect to the new selection screens before launching the puzzle
- style the new selection experience and temporarily point all problems to the existing maze pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae38dd8708329a48548d9b5564383