### PR TITLE
Handle problem selection only on PC and add mobile wait state

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -131,6 +131,125 @@ body {
     }
   }
 
+  &.page-problem-select {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+
+    main {
+      width: min(600px, 90vw);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      text-align: center;
+      background: #ffffff;
+      padding: 3rem 2.5rem;
+      border-radius: 1.5rem;
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+    }
+
+    .code-display {
+      font-size: 1.4rem;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      margin: 0;
+    }
+
+    .select-instruction {
+      margin: 0;
+      color: #555;
+    }
+
+    .problem-select {
+      width: 100%;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 1rem;
+
+      button {
+        font-size: 1.2rem;
+        padding: 1rem 0;
+        border-radius: 1rem;
+        border: none;
+        background: #355cdd;
+        color: #fff;
+        font-weight: 700;
+        cursor: pointer;
+        box-shadow: 0 4px 14px rgba(53, 92, 221, 0.25);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+        &:hover,
+        &:focus-visible {
+          transform: translateY(-2px);
+          box-shadow: 0 6px 18px rgba(53, 92, 221, 0.35);
+        }
+
+        &:active {
+          transform: translateY(1px);
+          box-shadow: 0 3px 10px rgba(53, 92, 221, 0.3);
+        }
+      }
+    }
+  }
+
+  &.page-mobile-wait {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background: linear-gradient(180deg, #f7f7f7 0%, #f0f4ff 100%);
+
+    main {
+      width: min(520px, 90vw);
+      background: #ffffff;
+      border-radius: 1.5rem;
+      padding: 3rem 2.5rem;
+      box-shadow: 0 10px 28px rgba(0, 0, 0, 0.1);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+      text-align: center;
+    }
+
+    .code-display {
+      font-size: 1.4rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      margin: 0;
+    }
+
+    .wait-instruction {
+      margin: 0;
+      color: #555;
+    }
+
+    .wait-indicator {
+      display: flex;
+      gap: 0.6rem;
+      margin-top: 1rem;
+
+      span {
+        width: 0.9rem;
+        height: 0.9rem;
+        border-radius: 50%;
+        background: #355cdd;
+        opacity: 0.3;
+        animation: waitPulse 1.2s infinite ease-in-out;
+
+        &:nth-child(2) {
+          animation-delay: 0.2s;
+        }
+
+        &:nth-child(3) {
+          animation-delay: 0.4s;
+        }
+      }
+    }
+  }
+
   &.page-mobile-controller {
     display: flex;
     flex-direction: column;
@@ -234,5 +353,19 @@ body {
         }
       }
     }
+  }
+}
+
+@keyframes waitPulse {
+  0%,
+  80%,
+ 100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+
+  40% {
+    opacity: 1;
+    transform: translateY(-0.3rem);
   }
 }

--- a/js/mobile-wait.js
+++ b/js/mobile-wait.js
@@ -1,0 +1,63 @@
+(() => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code') || '';
+  const codeDisplay = document.querySelector('[data-code-display]');
+
+  if (codeDisplay) {
+    codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
+  }
+
+  const destinationMap = {
+    '1': 'mobile-next.html',
+    '2': 'mobile-next.html',
+    '3': 'mobile-next.html',
+    '4': 'mobile-next.html',
+    '5': 'mobile-next.html'
+  };
+
+  const socket = io('https://ws.u-tahara.jp', {
+    transports: ['websocket'],
+    withCredentials: true
+  });
+
+  const joinRoom = () => {
+    if (!code) return;
+    socket.emit('join', { room: code, role: 'mobile' });
+  };
+
+  socket.on('connect', () => {
+    joinRoom();
+  });
+
+  const goToProblem = (problem, destinations) => {
+    const fallbackDestination = destinationMap[problem] || destinationMap['1'];
+    const mobileDest = destinations?.mobile || fallbackDestination || 'mobile-next.html';
+    const url = code ? `${mobileDest}?code=${encodeURIComponent(code)}` : mobileDest;
+    window.location.href = url;
+  };
+
+  socket.on('problemSelected', (payload = {}) => {
+    const { room, problem, destinations } = payload;
+    if (!room || room !== code) return;
+    goToProblem(problem, destinations);
+  });
+
+  socket.on('status', ({ room, step, problem, destinations } = {}) => {
+    if (!room || room !== code) return;
+    if (step === 'problemSelected') {
+      goToProblem(problem, destinations);
+    }
+  });
+
+  socket.on('paired', ({ code: pairedCode } = {}) => {
+    if (!pairedCode || pairedCode !== code) return;
+    // ペア成立後に PC が選択済みだった場合のフォールバック
+  });
+
+  socket.on('memberUpdate', (info = {}) => {
+    if (info.type === 'leave' && info.count <= 1) {
+      // PCが離脱した場合は待機画面のまま
+      return;
+    }
+  });
+})();

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -51,23 +51,29 @@
   // ---- サーバーからのイベント ----
 
   // 旧実装互換: サーバーが「mobile用のstatus」を返すとき
-  socket.on('status', ({ role, code } = {}) => {
-    if (role === 'mobile') {
-      const c = code || currentCode;
-      location.href = `mobile-next.html?code=${encodeURIComponent(c)}`;
+  socket.on('status', ({ role, code, step, problem, destinations } = {}) => {
+    if (role !== 'mobile') return;
+    const c = code || currentCode;
+
+    if (step === 'problemSelected') {
+      const mobileDest = destinations?.mobile || 'mobile-next.html';
+      location.href = `${mobileDest}?code=${encodeURIComponent(c)}`;
+      return;
     }
+
+    location.href = `mobile-problem.html?code=${encodeURIComponent(c)}`;
   });
 
   // 新実装: PCとスマホの“同時遷移”合図
   socket.on('paired', ({ code } = {}) => {
     const c = code || currentCode;
-    location.href = `mobile-next.html?code=${encodeURIComponent(c)}`;
+    location.href = `mobile-problem.html?code=${encodeURIComponent(c)}`;
   });
 
   // 互換フォールバック: “部屋の人数更新”で2人以上になったら遷移
   socket.on('memberUpdate', (info = {}) => {
     if (info.type === 'join' && typeof info.count === 'number' && info.count >= 2) {
-      location.href = `mobile-next.html?code=${encodeURIComponent(currentCode)}`;
+      location.href = `mobile-problem.html?code=${encodeURIComponent(currentCode)}`;
     }
   });
 

--- a/js/pc-problem.js
+++ b/js/pc-problem.js
@@ -1,0 +1,116 @@
+(() => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code') || '';
+  const codeDisplay = document.querySelector('[data-code-display]');
+  const buttons = document.querySelectorAll('[data-problem]');
+
+  if (codeDisplay) {
+    codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
+  }
+
+  const destinationMap = {
+    '1': { pc: 'pc-next.html', mobile: 'mobile-next.html' },
+    '2': { pc: 'pc-next.html', mobile: 'mobile-next.html' },
+    '3': { pc: 'pc-next.html', mobile: 'mobile-next.html' },
+    '4': { pc: 'pc-next.html', mobile: 'mobile-next.html' },
+    '5': { pc: 'pc-next.html', mobile: 'mobile-next.html' }
+  };
+
+  const socket = io('https://ws.u-tahara.jp', {
+    transports: ['websocket'],
+    withCredentials: true
+  });
+
+  const pendingQueue = [];
+
+  const emitQueued = () => {
+    if (!socket.connected) return;
+    while (pendingQueue.length) {
+      const payload = pendingQueue.shift();
+      socket.emit('problemSelected', payload);
+      socket.emit('status', {
+        role: 'mobile',
+        code,
+        room: code,
+        step: 'problemSelected',
+        problem: payload?.problem,
+        destinations: payload?.destinations
+      });
+    }
+  };
+
+  const joinRoom = () => {
+    if (!code) return;
+    socket.emit('join', { room: code, role: 'pc' });
+  };
+
+  socket.on('connect', () => {
+    joinRoom();
+    emitQueued();
+  });
+
+  socket.on('problemSelected', (payload = {}) => {
+    const { room, code: payloadCode, problem } = payload;
+    const roomCode = room || payloadCode;
+    if (!roomCode || roomCode !== code) return;
+    goToProblem(problem);
+  });
+
+  socket.on('disconnect', () => {
+    // 再接続時に部屋へ復帰する
+    // Socket.IO が自動再接続後に connect を発火するため特別な処理は不要
+  });
+
+  const goToProblem = (problem) => {
+    const entry = destinationMap[problem] || destinationMap['1'];
+    if (!entry) return;
+    const dest = entry.pc;
+    const url = code ? `${dest}?code=${encodeURIComponent(code)}` : dest;
+    window.location.href = url;
+  };
+
+  const notifySelection = (problem) => {
+    if (!code) return;
+    const entry = destinationMap[problem] || destinationMap['1'];
+    if (!entry) return;
+
+    const payload = {
+      room: code,
+      code,
+      problem,
+      destinations: entry
+    };
+
+    if (socket.connected) {
+      socket.emit('problemSelected', payload);
+      socket.emit('status', {
+        role: 'mobile',
+        code,
+        room: code,
+        step: 'problemSelected',
+        problem,
+        destinations: entry
+      });
+    } else {
+      pendingQueue.length = 0;
+      pendingQueue.push(payload);
+    }
+  };
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const { problem } = button.dataset;
+      if (!problem) return;
+
+      buttons.forEach((b) => {
+        b.disabled = true;
+      });
+
+      notifySelection(problem);
+      // イベント送信から遷移まで僅かな余裕を持たせる
+      setTimeout(() => {
+        goToProblem(problem);
+      }, 120);
+    });
+  });
+})();

--- a/js/pc.js
+++ b/js/pc.js
@@ -31,14 +31,14 @@
   // 🔴 スマホが同じコードで入室した合図（同時遷移）
   socket.on('paired', ({ code } = {}) => {
     const c = code || currentCode || '';
-    location.href = `pc-next.html?code=${encodeURIComponent(c)}`;
+    location.href = `pc-problem.html?code=${encodeURIComponent(c)}`;
   });
 
   // 互換フォールバック：メンバー数イベントで2人以上になったら遷移
   socket.on('memberUpdate', (info = {}) => {
     if (info.type === 'join' && typeof info.count === 'number' && info.count >= 2) {
       const c = currentCode || '';
-      location.href = `pc-next.html?code=${encodeURIComponent(c)}`;
+      location.href = `pc-problem.html?code=${encodeURIComponent(c)}`;
     }
   });
 

--- a/mobile-problem.html
+++ b/mobile-problem.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>スマホ - 問題開始待機</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+    <script src="js/mobile-wait.js" defer></script>
+  </head>
+  <body class="page page-mobile-wait">
+    <main>
+      <h1>PC側で問題を選択中です</h1>
+      <p class="code-display" data-code-display></p>
+      <p class="wait-instruction">PCで問題が選択されるまでこのままお待ちください。</p>
+      <div class="wait-indicator" aria-hidden="true">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
+    </main>
+  </body>
+</html>

--- a/pc-problem.html
+++ b/pc-problem.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PC - 問題選択</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+    <script src="js/pc-problem.js" defer></script>
+  </head>
+  <body class="page page-problem-select page-pc-problem">
+    <main>
+      <h1>問題を選択</h1>
+      <p class="code-display" data-code-display></p>
+      <p class="select-instruction">解きたい問題番号を選択してください。</p>
+      <div class="problem-select">
+        <button type="button" data-problem="1">問題1</button>
+        <button type="button" data-problem="2">問題2</button>
+        <button type="button" data-problem="3">問題3</button>
+        <button type="button" data-problem="4">問題4</button>
+        <button type="button" data-problem="5">問題5</button>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- ensure the PC problem picker notifies the paired room and triggers both clients to open the puzzle
- replace the mobile problem picker with a waiting screen and listener for the PC selection
- style the waiting screen for clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dae38dd8708329a48548d9b5564383