### PR TITLE
Add back navigation to next screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,6 +14,35 @@ body {
   background-color: #f7f7f7;
   color: #1f1f1f;
 
+  .page-footer {
+    margin: 0 0 3rem;
+    text-align: center;
+  }
+
+  .page-footer .back-button {
+    display: inline-block;
+    padding: 0.8rem 2.2rem;
+    border-radius: 1.5rem;
+    background: #4caf50;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 700;
+    box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);
+    transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+
+    &:hover,
+    &:focus-visible {
+      background: #388e3c;
+      box-shadow: 0 6px 16px rgba(56, 142, 60, 0.35);
+      transform: translateY(-1px);
+    }
+
+    &:active {
+      transform: translateY(1px);
+      box-shadow: 0 3px 10px rgba(56, 142, 60, 0.3);
+    }
+  }
+
   main {
     width: min(960px, 90vw);
     margin: 0 auto;

--- a/mobile-next.html
+++ b/mobile-next.html
@@ -14,5 +14,8 @@
       <button type="button" data-direction="down">↓</button>
       <button type="button" data-direction="right">→</button>
     </div>
+    <div class="page-footer">
+      <a class="back-button" href="mobile-problem.html">問題に戻る</a>
+    </div>
   </body>
 </html>

--- a/pc-next.html
+++ b/pc-next.html
@@ -9,5 +9,8 @@
   <body class="page page-pc-maze">
     <h1>迷路</h1>
     <div id="maze" aria-live="polite"></div>
+    <div class="page-footer">
+      <a class="back-button" href="pc-problem.html">問題に戻る</a>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add navigation buttons on the PC and mobile next pages that return to their respective problem selection screens
- introduce shared styling for the new back buttons so they match the site's design

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68daf44fc1f883298c477d1ee74e2ef3