### PR TITLE
Sync back navigation actions across devices

### DIFF
--- a/mobile-next.html
+++ b/mobile-next.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <title>スマホコントローラー</title>
     <link rel="stylesheet" href="css/styles.css" />
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
     <script src="js/mobile-next.js" defer></script>
   </head>
   <body class="page page-mobile-controller">

--- a/pc-next.html
+++ b/pc-next.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <title>PC - 迷路</title>
     <link rel="stylesheet" href="css/styles.css" />
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
     <script src="js/pc-next.js" defer></script>
   </head>
   <body class="page page-pc-maze">

--- a/server.js
+++ b/server.js
@@ -149,6 +149,21 @@ io.on('connection', (socket) => {
     io.to(code).emit('status', { room: code, code, step: 'problemSelected', problem, destinations });
   });
 
+  socket.on('navigateBack', (payload = {}) => {
+    const code = sanitizeCode(payload.room || payload.code || socket.data.room);
+    if (!code || code.length !== CODE_LEN) return;
+
+    const role = typeof payload.role === 'string' ? payload.role : undefined;
+
+    roomStates.set(code, { step: 'problemSelection' });
+
+    const notifyPayload = { room: code, code };
+    if (role) notifyPayload.from = role;
+
+    socket.to(code).emit('navigateBack', notifyPayload);
+    io.to(code).emit('status', { room: code, code, step: 'problemSelection', from: role });
+  });
+
   socket.on('disconnect', () => {
     const room = socket.data.room;
     if (!room) return;


### PR DESCRIPTION
## Summary
- add a Socket.IO `navigateBack` event so that returning to the problem screen updates the shared room state
- update the PC and mobile "next" pages to emit the new event on back actions and respond to remote requests
- wire the browser back button and "問題に戻る" links to keep both devices synchronized

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68daf5a25ea08329abebfb49a0a1732a