### PR TITLE
Enable Socket.IO-based maze control

### DIFF
--- a/js/mobile-next.js
+++ b/js/mobile-next.js
@@ -1,8 +1,7 @@
 const controller = document.querySelector('.controller');
 const code = new URLSearchParams(window.location.search).get('code');
-const controllerSocket = new WebSocket('https://ws.u-tahara.jp');
 
-const navigationSocket = io('https://ws.u-tahara.jp', {
+const navigationSocket = io('/', {
   transports: ['websocket'],
   withCredentials: true,
 });
@@ -78,10 +77,6 @@ navigationSocket.on('navigateBack', ({ room, code: payloadCode } = {}) => {
 
 setupBackNavigation();
 
-controllerSocket.addEventListener('open', () => {
-  controllerSocket.send(JSON.stringify({ type: 'resume', role: 'mobile', code }));
-});
-
 if (controller) {
   controller.addEventListener('click', (event) => {
     const button = event.target.closest('button[data-direction]');
@@ -90,6 +85,6 @@ if (controller) {
     }
 
     const { direction } = button.dataset;
-    controllerSocket.send(JSON.stringify({ type: 'move', direction }));
+    navigationSocket.emit('moveDirection', { room: code, direction });
   });
 }


### PR DESCRIPTION
## Summary
- update the PC maze to receive direction events over the existing Socket.IO channel
- send smartphone button presses as directional events through Socket.IO
- extend the server to relay directional moves and remember the sender role

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68daf8a42cd88329a32ebf7a8804f9bb