### PR TITLE
Adjust maze grid width to match configuration

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -356,7 +356,7 @@ body {
 
     #maze {
       display: grid;
-      grid-template-columns: repeat(5, 60px);
+      grid-template-columns: repeat(var(--maze-width, 5), 60px);
       gap: 4px;
       margin: 2.5rem auto;
       box-shadow: 0 6px 24px rgba(0, 0, 0, 0.1);

--- a/js/pc-gyro.js
+++ b/js/pc-gyro.js
@@ -129,12 +129,14 @@ function drawMaze() {
     return;
   }
 
+  mazeContainer.style.setProperty('--maze-width', String(width));
   mazeContainer.innerHTML = '';
   for (let y = 0; y < height; y += 1) {
+    const row = Array.isArray(mazeMap[y]) ? mazeMap[y] : [];
     for (let x = 0; x < width; x += 1) {
       const div = document.createElement('div');
       div.classList.add('cell');
-      if (mazeMap[y][x] === 1) div.classList.add('wall');
+      if (row[x] === 1) div.classList.add('wall');
       if (x === player.x && y === player.y) div.classList.add('player');
       if (x === goal.x && y === goal.y) div.classList.add('goal');
       mazeContainer.appendChild(div);

--- a/js/pc-next.js
+++ b/js/pc-next.js
@@ -139,12 +139,14 @@ function drawMaze() {
     return;
   }
 
+  mazeContainer.style.setProperty('--maze-width', String(width));
   mazeContainer.innerHTML = '';
   for (let y = 0; y < height; y += 1) {
+    const row = Array.isArray(mazeMap[y]) ? mazeMap[y] : [];
     for (let x = 0; x < width; x += 1) {
       const div = document.createElement('div');
       div.classList.add('cell');
-      if (mazeMap[y][x] === 1) div.classList.add('wall');
+      if (row[x] === 1) div.classList.add('wall');
       if (x === player.x && y === player.y) div.classList.add('player');
       if (x === goal.x && y === goal.y) div.classList.add('goal');
       mazeContainer.appendChild(div);


### PR DESCRIPTION
## Summary
- use a CSS custom property so the maze grid respects the configured width
- update the gyro and next PC maze renders to set the grid width and guard against malformed rows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db0cf69f608329b3d03d0f8adf5e66