### PR TITLE
Adjust problem3 brightness reveal threshold

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -423,8 +423,26 @@ body {
       letter-spacing: 0.24em;
       text-transform: uppercase;
       color: rgba(255, 255, 255, 0.94);
-      text-shadow: 0 0 18px rgba(0, 0, 0, 0.25);
       margin: 0;
+    }
+
+    .password-lead,
+    .password-display {
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.4s ease;
+    }
+
+    .password-lead[data-hidden],
+    .password-display[data-hidden] {
+      opacity: 0;
+      visibility: hidden;
+    }
+
+    .password-lead:not([data-hidden]),
+    .password-display:not([data-hidden]) {
+      opacity: 1;
+      visibility: visible;
     }
 
     .instructions {

--- a/js/pc-problem3.js
+++ b/js/pc-problem3.js
@@ -3,6 +3,7 @@
   const code = params.get('code') || '';
   const main = document.querySelector('main[data-password]');
   const passwordDisplay = document.querySelector('[data-password-text]');
+  const passwordLead = document.querySelector('.password-lead');
   const codeDisplay = document.querySelector('[data-code-display]');
   const backButton = document.querySelector('.back-button');
   const body = document.body;
@@ -26,11 +27,26 @@
     return number;
   };
 
+  const DARKNESS_THRESHOLD = 0.35;
+
+  const updatePasswordVisibility = (level) => {
+    const isDarkEnough = level <= DARKNESS_THRESHOLD;
+    if (passwordDisplay) {
+      passwordDisplay.toggleAttribute('data-hidden', !isDarkEnough);
+    }
+
+    if (passwordLead) {
+      passwordLead.toggleAttribute('data-hidden', !isDarkEnough);
+    }
+
+  };
+
   const applyLightLevel = (rawLevel) => {
     const level = clamp(rawLevel);
     const shade = Math.round(level * 255);
     body.style.setProperty('--light-level', String(level));
     body.style.backgroundColor = `rgb(${shade}, ${shade}, ${shade})`;
+    updatePasswordVisibility(level);
   };
 
   applyLightLevel(1);


### PR DESCRIPTION
## Summary
- hide the problem3 password until the light sensor reports a sufficiently dark environment
- remove the glowing text shadow and add smooth fade-in styling for the password reveal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db15600e4083299ef81f7bda2df4f9