### PR TITLE
Display entry message before auto redirect

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -96,6 +96,14 @@ body {
         }
       }
     }
+
+    .auto-redirect-message {
+      margin-top: 2.5rem;
+      font-size: 1.2rem;
+      font-weight: 600;
+      color: #333;
+      text-align: center;
+    }
   }
 
   &.page-mobile {

--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
         <button id="pcBtn" type="button">PCで開く</button>
         <button id="spBtn" type="button">スマホで開く</button>
       </div>
+      <p id="autoRedirectMessage" class="auto-redirect-message" hidden aria-live="polite">
+        PC or スマホ 端末で入室しました
+      </p>
     </main>
   </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,6 @@
 const pcButton = document.getElementById('pcBtn');
 const mobileButton = document.getElementById('spBtn');
+const autoRedirectMessage = document.getElementById('autoRedirectMessage');
 
 const redirectTo = (path) => {
   if (!path) return;
@@ -57,6 +58,12 @@ if (mobileButton) {
 window.addEventListener('DOMContentLoaded', () => {
   const destination = determineDestination();
   if (destination) {
-    redirectTo(destination);
+    if (autoRedirectMessage) {
+      autoRedirectMessage.hidden = false;
+      autoRedirectMessage.textContent = 'PC or スマホ 端末で入室しました';
+    }
+    setTimeout(() => {
+      redirectTo(destination);
+    }, 2000);
   }
 });


### PR DESCRIPTION
## Summary
- show an entry notice when OS detection triggers an automatic redirect on the device selection page
- delay navigation by two seconds so the message is visible and style the message for visibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd323af3308329a0338e9daf4148fd