### PR TITLE
Show detection status before redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <button id="spBtn" type="button">スマホで開く</button>
       </div>
       <p id="autoRedirectMessage" class="auto-redirect-message" hidden aria-live="polite">
-        PC or スマホ 端末で入室しました
+        端末認識中
       </p>
     </main>
   </body>

--- a/js/index.js
+++ b/js/index.js
@@ -56,14 +56,24 @@ if (mobileButton) {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+  if (autoRedirectMessage) {
+    autoRedirectMessage.hidden = false;
+    autoRedirectMessage.textContent = '端末認識中';
+  }
+
   const destination = determineDestination();
   if (destination) {
     if (autoRedirectMessage) {
-      autoRedirectMessage.hidden = false;
-      autoRedirectMessage.textContent = 'PC or スマホ 端末で入室しました';
+      const message = destination === 'pc.html' ? 'PC端末で入室しました' : 'スマホ端末で入室しました';
+      autoRedirectMessage.textContent = message;
     }
     setTimeout(() => {
       redirectTo(destination);
     }, 2000);
+    return;
+  }
+
+  if (autoRedirectMessage) {
+    autoRedirectMessage.hidden = true;
   }
 });


### PR DESCRIPTION
## Summary
- display a "端末認識中" status message before determining the device on index.html
- update the auto redirect logic to swap the message to the PC/スマホ variant once detection finishes and hide it if detection fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd339a6a748329ab9d9a7b1e458b82