### PR TITLE
Persist PC connection code via session storage

### DIFF
--- a/js/mobile-problem5.js
+++ b/js/mobile-problem5.js
@@ -16,8 +16,47 @@
     return Math.sqrt(sum / data.length);
   });
 
-  const params = new URLSearchParams(window.location.search);
-  const code = params.get('code') || '';
+  const CODE_STORAGE_KEY = 'cross-key-puzzle:code';
+
+  const readCodeFromQuery = () => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return (params.get('code') || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const readStoredCode = () => {
+    try {
+      const stored = window.sessionStorage?.getItem(CODE_STORAGE_KEY);
+      return (stored || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const storeCode = (value) => {
+    if (!value) return;
+    try {
+      window.sessionStorage?.setItem(CODE_STORAGE_KEY, value);
+    } catch (error) {
+      // セッションストレージが利用できない場合は無視
+    }
+  };
+
+  const code = (() => {
+    const codeFromQuery = readCodeFromQuery();
+    if (codeFromQuery) {
+      storeCode(codeFromQuery);
+      return codeFromQuery;
+    }
+    const stored = readStoredCode();
+    if (stored) {
+      return stored;
+    }
+    return '';
+  })();
 
   const main = document.querySelector('main[data-password]');
   const codeDisplay = document.querySelector('[data-code-display]');

--- a/js/mobile-problem6.js
+++ b/js/mobile-problem6.js
@@ -31,8 +31,47 @@
   });
   const DEFAULT_REQUIRED = Number.isFinite(shakeUtils.DEFAULT_REQUIRED) ? shakeUtils.DEFAULT_REQUIRED : 8;
 
-  const params = new URLSearchParams(window.location.search);
-  const code = params.get('code') || '';
+  const CODE_STORAGE_KEY = 'cross-key-puzzle:code';
+
+  const readCodeFromQuery = () => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return (params.get('code') || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const readStoredCode = () => {
+    try {
+      const stored = window.sessionStorage?.getItem(CODE_STORAGE_KEY);
+      return (stored || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const storeCode = (value) => {
+    if (!value) return;
+    try {
+      window.sessionStorage?.setItem(CODE_STORAGE_KEY, value);
+    } catch (error) {
+      // セッションストレージが利用できない場合は無視
+    }
+  };
+
+  const code = (() => {
+    const codeFromQuery = readCodeFromQuery();
+    if (codeFromQuery) {
+      storeCode(codeFromQuery);
+      return codeFromQuery;
+    }
+    const stored = readStoredCode();
+    if (stored) {
+      return stored;
+    }
+    return '';
+  })();
 
   const main = document.querySelector('main[data-password]');
   const codeDisplay = document.querySelector('[data-code-display]');

--- a/js/mobile-wait.js
+++ b/js/mobile-wait.js
@@ -1,6 +1,45 @@
 (() => {
-  const params = new URLSearchParams(window.location.search);
-  const code = params.get('code') || '';
+  const CODE_STORAGE_KEY = 'cross-key-puzzle:code';
+
+  const readCodeFromQuery = () => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return (params.get('code') || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const readStoredCode = () => {
+    try {
+      const stored = window.sessionStorage?.getItem(CODE_STORAGE_KEY);
+      return (stored || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const storeCode = (value) => {
+    if (!value) return;
+    try {
+      window.sessionStorage?.setItem(CODE_STORAGE_KEY, value);
+    } catch (error) {
+      // セッションストレージが利用できない場合は無視
+    }
+  };
+
+  const code = (() => {
+    const codeFromQuery = readCodeFromQuery();
+    if (codeFromQuery) {
+      storeCode(codeFromQuery);
+      return codeFromQuery;
+    }
+    const stored = readStoredCode();
+    if (stored) {
+      return stored;
+    }
+    return '';
+  })();
   const codeDisplay = document.querySelector('[data-code-display]');
 
   if (codeDisplay) {

--- a/js/pc-problem.js
+++ b/js/pc-problem.js
@@ -1,6 +1,45 @@
 (() => {
-  const params = new URLSearchParams(window.location.search);
-  const code = params.get('code') || '';
+  const CODE_STORAGE_KEY = 'cross-key-puzzle:code';
+
+  const readCodeFromQuery = () => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return (params.get('code') || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const readStoredCode = () => {
+    try {
+      const stored = window.sessionStorage?.getItem(CODE_STORAGE_KEY);
+      return (stored || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const storeCode = (value) => {
+    if (!value) return;
+    try {
+      window.sessionStorage?.setItem(CODE_STORAGE_KEY, value);
+    } catch (error) {
+      // セッションストレージが利用できない場合は無視
+    }
+  };
+
+  const code = (() => {
+    const codeFromQuery = readCodeFromQuery();
+    if (codeFromQuery) {
+      storeCode(codeFromQuery);
+      return codeFromQuery;
+    }
+    const stored = readStoredCode();
+    if (stored) {
+      return stored;
+    }
+    return '';
+  })();
   const codeDisplay = document.querySelector('[data-code-display]');
   const buttons = document.querySelectorAll('[data-problem]');
 

--- a/js/pc-problem5.js
+++ b/js/pc-problem5.js
@@ -10,8 +10,47 @@
     ? audioUtils.DEFAULT_THRESHOLD
     : 0.35;
 
-  const params = new URLSearchParams(window.location.search);
-  const code = params.get('code') || '';
+  const CODE_STORAGE_KEY = 'cross-key-puzzle:code';
+
+  const readCodeFromQuery = () => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return (params.get('code') || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const readStoredCode = () => {
+    try {
+      const stored = window.sessionStorage?.getItem(CODE_STORAGE_KEY);
+      return (stored || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const storeCode = (value) => {
+    if (!value) return;
+    try {
+      window.sessionStorage?.setItem(CODE_STORAGE_KEY, value);
+    } catch (error) {
+      // セッションストレージが利用できない場合は無視
+    }
+  };
+
+  const code = (() => {
+    const codeFromQuery = readCodeFromQuery();
+    if (codeFromQuery) {
+      storeCode(codeFromQuery);
+      return codeFromQuery;
+    }
+    const stored = readStoredCode();
+    if (stored) {
+      return stored;
+    }
+    return '';
+  })();
 
   const main = document.querySelector('main[data-password]');
   const codeDisplay = document.querySelector('[data-code-display]');

--- a/js/pc-problem6.js
+++ b/js/pc-problem6.js
@@ -4,8 +4,47 @@
     ? shakeUtils.DEFAULT_REQUIRED
     : 8;
 
-  const params = new URLSearchParams(window.location.search);
-  const code = params.get('code') || '';
+  const CODE_STORAGE_KEY = 'cross-key-puzzle:code';
+
+  const readCodeFromQuery = () => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return (params.get('code') || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const readStoredCode = () => {
+    try {
+      const stored = window.sessionStorage?.getItem(CODE_STORAGE_KEY);
+      return (stored || '').trim();
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const storeCode = (value) => {
+    if (!value) return;
+    try {
+      window.sessionStorage?.setItem(CODE_STORAGE_KEY, value);
+    } catch (error) {
+      // セッションストレージが利用できない場合は無視
+    }
+  };
+
+  const code = (() => {
+    const codeFromQuery = readCodeFromQuery();
+    if (codeFromQuery) {
+      storeCode(codeFromQuery);
+      return codeFromQuery;
+    }
+    const stored = readStoredCode();
+    if (stored) {
+      return stored;
+    }
+    return '';
+  })();
 
   const main = document.querySelector('main[data-password]');
   const codeDisplay = document.querySelector('[data-code-display]');


### PR DESCRIPTION
## Summary
- store the generated PC connection code in sessionStorage so it can be reused across pages
- fall back to the stored code on the PC problem list and problems 5/6 when the query parameter is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68debb7ffc6883299b4e8f4261561e9c