### PR TITLE
Handle status resets on problems 5 and 6

### DIFF
--- a/js/mobile-problem5.js
+++ b/js/mobile-problem5.js
@@ -342,9 +342,13 @@
     });
   }
 
-  navigationSocket.on('status', ({ room, code: payloadCode, audio } = {}) => {
+  navigationSocket.on('status', ({ room, code: payloadCode, step, audio } = {}) => {
     const roomCode = room || payloadCode;
     if (!roomCode || (code && roomCode !== code)) return;
+    if (step === 'problemSelection') {
+      goBackToProblem();
+      return;
+    }
     if (audio && typeof audio.level === 'number') {
       setLevel(audio.level);
     }

--- a/js/mobile-problem6.js
+++ b/js/mobile-problem6.js
@@ -331,9 +331,13 @@
     });
   }
 
-  navigationSocket.on('status', ({ room, code: payloadCode, shake } = {}) => {
+  navigationSocket.on('status', ({ room, code: payloadCode, step, shake } = {}) => {
     const roomCode = room || payloadCode;
     if (!roomCode || (code && roomCode !== code)) return;
+    if (step === 'problemSelection') {
+      goBackToProblem();
+      return;
+    }
     if (shake && typeof shake.count === 'number') {
       setCountValue(shake.count);
     }


### PR DESCRIPTION
## Summary
- make the PC problem 5 and 6 pages return to the selection screen when a status update signals a reset
- ensure the mobile problem 5 and 6 pages also navigate back when the room status returns to problem selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec01bae808329a80b71bc1017f7e6