### PR TITLE
Add animated loading screen and gradient background

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,3 +1,36 @@
+@keyframes gradientFlow {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes logoFadeIn {
+  0% {
+    opacity: 0;
+    transform: translateY(18px) scale(0.96);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(0) scale(1.02);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes spinnerRotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 :root {
   color-scheme: light;
 }
@@ -11,8 +44,11 @@ body {
   padding: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.5;
-  background-color: #f7f7f7;
+  background: linear-gradient(135deg, #ff6ec4, #7873f5, #4ac29a, #fbe29f);
+  background-size: 320% 320%;
+  animation: gradientFlow 24s ease infinite;
   color: #1f1f1f;
+  min-height: 100vh;
 
   .page-footer {
     margin: 0 0 3rem;
@@ -66,43 +102,49 @@ body {
       padding: 0;
     }
 
-    #deviceSelect {
+    .loading-screen {
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 2rem;
+      gap: 1.75rem;
+      padding: 3.5rem 2.5rem;
+      border-radius: 1.5rem;
+      background: rgba(255, 255, 255, 0.82);
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.2);
+      backdrop-filter: blur(6px);
+      text-align: center;
+      transition: background 0.4s ease;
+    }
 
-      button {
-        font-size: 1.6rem;
-        padding: 1.5rem 0;
-        border-radius: 1rem;
-        border: none;
-        background: #4caf50;
-        color: #fff;
-        font-weight: bold;
-        cursor: pointer;
-        margin: 0.5rem 0;
-        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-        transition: background 0.2s ease;
-        width: 320px;
-        max-width: 90vw;
-        min-width: 220px;
-        display: block;
+    .loading-logo {
+      width: min(240px, 70vw);
+      opacity: 0;
+      animation: logoFadeIn 1.2s ease forwards;
+    }
 
-        &:hover,
-        &:focus-visible {
-          background: #388e3c;
-        }
-      }
+    .loading-spinner {
+      width: 70px;
+      height: 70px;
+      border-radius: 50%;
+      border: 6px solid rgba(120, 115, 245, 0.25);
+      border-top-color: rgba(120, 115, 245, 0.85);
+      border-right-color: rgba(74, 194, 154, 0.85);
+      animation: spinnerRotate 1.1s linear infinite;
+    }
+
+    .loading-spinner.is-hidden {
+      display: none;
     }
 
     .auto-redirect-message {
-      margin-top: 2.5rem;
+      margin: 0;
       font-size: 1.2rem;
       font-weight: 600;
-      color: #333;
+      color: #24324b;
       text-align: center;
+      line-height: 1.7;
+      max-width: 24ch;
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -8,13 +8,17 @@
   </head>
   <body class="page page-index">
     <main>
-      <div id="deviceSelect">
-        <button id="pcBtn" type="button">PCで開く</button>
-        <button id="spBtn" type="button">スマホで開く</button>
+      <div class="loading-screen" role="status" aria-live="polite" aria-busy="true">
+        <img
+          src="img/common/logo.png"
+          alt="Cross Key Puzzle のロゴ"
+          class="loading-logo"
+        />
+        <div class="loading-spinner" aria-hidden="true"></div>
+        <p id="autoRedirectMessage" class="auto-redirect-message">
+          端末情報を取得しています...
+        </p>
       </div>
-      <p id="autoRedirectMessage" class="auto-redirect-message" hidden aria-live="polite">
-        端末認識中
-      </p>
     </main>
   </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,6 @@
-const pcButton = document.getElementById('pcBtn');
-const mobileButton = document.getElementById('spBtn');
 const autoRedirectMessage = document.getElementById('autoRedirectMessage');
+const loadingSpinner = document.querySelector('.loading-spinner');
+const loadingScreen = document.querySelector('.loading-screen');
 
 const redirectTo = (path) => {
   if (!path) return;
@@ -43,28 +43,21 @@ const determineDestination = () => {
   return null;
 };
 
-if (pcButton) {
-  pcButton.addEventListener('click', () => {
-    redirectTo('pc.html');
-  });
-}
-
-if (mobileButton) {
-  mobileButton.addEventListener('click', () => {
-    redirectTo('mobile.html');
-  });
-}
-
 window.addEventListener('DOMContentLoaded', () => {
   if (autoRedirectMessage) {
-    autoRedirectMessage.hidden = false;
-    autoRedirectMessage.textContent = '端末認識中';
+    autoRedirectMessage.textContent = '端末情報を取得しています...';
+  }
+
+  if (loadingScreen) {
+    loadingScreen.setAttribute('aria-busy', 'true');
   }
 
   const destination = determineDestination();
   if (destination) {
     if (autoRedirectMessage) {
-      const message = destination === 'pc.html' ? 'PC端末で入室しました' : 'スマホ端末で入室しました';
+      const message = destination === 'pc.html'
+        ? 'PC端末を確認しました。まもなく移動します。'
+        : 'スマホ端末を確認しました。まもなく移動します。';
       autoRedirectMessage.textContent = message;
     }
     setTimeout(() => {
@@ -74,6 +67,14 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   if (autoRedirectMessage) {
-    autoRedirectMessage.hidden = true;
+    autoRedirectMessage.textContent = '端末を判別できませんでした。PC版またはスマホ版のページを直接開いてください。';
+  }
+
+  if (loadingSpinner) {
+    loadingSpinner.classList.add('is-hidden');
+  }
+
+  if (loadingScreen) {
+    loadingScreen.setAttribute('aria-busy', 'false');
   }
 });


### PR DESCRIPTION
## Summary
- replace the device selection buttons with a logo-driven loading screen while detecting the device
- animate the Cross Key Puzzle logo and loading spinner, and add messaging for successful and failed detection paths
- apply a colorful animated gradient background shared across every page

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68e0022169448329867414d7c167d897