### PR TITLE
Add clear page and navigation for completed puzzles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -443,6 +443,44 @@ body {
     }
   }
 
+  &.page-pc-clear {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+
+    main {
+      width: min(640px, 90vw);
+      text-align: center;
+      background: rgba(255, 255, 255, 0.85);
+      padding: 3rem 2.5rem;
+      border-radius: 1.75rem;
+      box-shadow: 0 20px 45px rgba(0, 0, 0, 0.18);
+      backdrop-filter: blur(4px);
+    }
+
+    h1 {
+      margin-top: 0;
+      margin-bottom: 1.5rem;
+      font-size: clamp(2rem, 4vw, 2.6rem);
+      color: #2d3a5b;
+    }
+
+    .clear-message {
+      margin: 0 0 2.5rem;
+      font-size: 1.15rem;
+      color: #3f4c6b;
+      line-height: 1.8;
+    }
+
+    .code-display {
+      margin-bottom: 0.75rem;
+      font-weight: 600;
+      color: #24324b;
+    }
+  }
+
   &.page-pc-problem3 {
     min-height: 100vh;
     background: #ffffff;

--- a/js/pc-clear.js
+++ b/js/pc-clear.js
@@ -1,0 +1,92 @@
+(() => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code') || '';
+  const codeDisplay = document.querySelector('[data-code-display]');
+  const backButton = document.querySelector('[data-back-button]');
+
+  if (codeDisplay) {
+    codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
+  }
+
+  const resolveNavigationEndpoint = () => {
+    const helper = window.NavigationWs?.detectNavigationWsEndpoint;
+    if (typeof helper === 'function') {
+      return helper();
+    }
+    return 'https://ws.u-tahara.jp';
+  };
+
+  const navigationSocket = io(resolveNavigationEndpoint(), {
+    transports: ['websocket', 'polling'],
+    withCredentials: true,
+  });
+
+  const joinRoom = () => {
+    if (!code) return;
+    navigationSocket.emit('join', { room: code, role: 'pc' });
+  };
+
+  if (navigationSocket.connected) {
+    joinRoom();
+  }
+
+  navigationSocket.on('connect', joinRoom);
+  navigationSocket.on('reconnect', joinRoom);
+
+  const notifyBackNavigation = () => {
+    if (!code) return;
+    navigationSocket.emit('navigateBack', { room: code, role: 'pc' });
+  };
+
+  const goBackToProblem = () => {
+    const baseUrl = 'pc-problem.html';
+    const url = code ? `${baseUrl}?code=${encodeURIComponent(code)}` : baseUrl;
+    window.location.replace(url);
+  };
+
+  const setupBackNavigation = () => {
+    if (!window.history || !window.history.pushState) {
+      return;
+    }
+
+    const stateKey = { page: 'pc-clear' };
+
+    try {
+      const currentState = window.history.state || {};
+      window.history.replaceState({ ...currentState, ...stateKey }, document.title);
+    } catch (error) {
+      return;
+    }
+
+    const handlePopState = () => {
+      window.removeEventListener('popstate', handlePopState);
+      notifyBackNavigation();
+      goBackToProblem();
+    };
+
+    window.addEventListener('popstate', handlePopState);
+
+    try {
+      const duplicatedState = { ...(window.history.state || {}), ...stateKey, duplicated: true };
+      window.history.pushState(duplicatedState, document.title);
+    } catch (error) {
+      window.removeEventListener('popstate', handlePopState);
+    }
+  };
+
+  if (backButton) {
+    backButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      notifyBackNavigation();
+      goBackToProblem();
+    });
+  }
+
+  navigationSocket.on('navigateBack', ({ room, code: payloadCode } = {}) => {
+    const roomCode = room || payloadCode;
+    if (!roomCode || (code && roomCode !== code)) return;
+    goBackToProblem();
+  });
+
+  setupBackNavigation();
+})();

--- a/js/pc-gyro.js
+++ b/js/pc-gyro.js
@@ -142,7 +142,13 @@ const player = {
   x: Number(fallbackConfig.start?.x) || 0,
   y: Number(fallbackConfig.start?.y) || 0,
 };
-let hasGoalAlerted = false;
+let hasNavigatedToClearPage = false;
+
+const goToClearPage = () => {
+  const baseUrl = 'pc-clear.html';
+  const url = code ? `${baseUrl}?code=${encodeURIComponent(code)}` : baseUrl;
+  window.location.replace(url);
+};
 
 function drawMaze() {
   if (!mazeContainer) {
@@ -190,7 +196,7 @@ const applyMazeConfig = (config = fallbackConfig, { resetPlayer = false, usingFa
     player.y = Number.isFinite(startY) ? startY : fallbackConfig.start.y;
   }
 
-  hasGoalAlerted = false;
+  hasNavigatedToClearPage = false;
   drawMaze();
 };
 
@@ -250,13 +256,15 @@ const updatePlayer = (position = {}) => {
 };
 
 const handleGoal = (goalReached) => {
-  if (goalReached && !hasGoalAlerted) {
-    hasGoalAlerted = true;
-    window.alert('ゴール！');
+  if (goalReached) {
+    if (!hasNavigatedToClearPage) {
+      hasNavigatedToClearPage = true;
+      goToClearPage();
+    }
+    return;
   }
-  if (!goalReached) {
-    hasGoalAlerted = false;
-  }
+
+  hasNavigatedToClearPage = false;
 };
 
 navigationSocket.on('status', ({ room, code: payloadCode, maze, mazeConfigKey, problem, goal: payloadGoal } = {}) => {

--- a/js/pc-next.js
+++ b/js/pc-next.js
@@ -132,7 +132,13 @@ if (!Number.isFinite(player.x) || !Number.isFinite(player.y)) {
   player.x = fallbackConfig.start.x;
   player.y = fallbackConfig.start.y;
 }
-let hasGoalAlerted = false;
+let hasNavigatedToClearPage = false;
+
+const goToClearPage = () => {
+  const baseUrl = 'pc-clear.html';
+  const url = code ? `${baseUrl}?code=${encodeURIComponent(code)}` : baseUrl;
+  window.location.replace(url);
+};
 
 function drawMaze() {
   if (!mazeContainer) {
@@ -167,13 +173,15 @@ const updatePlayer = (position = {}) => {
 };
 
 const handleGoal = (goalReached) => {
-  if (goalReached && !hasGoalAlerted) {
-    hasGoalAlerted = true;
-    window.alert('ゴール！');
+  if (goalReached) {
+    if (!hasNavigatedToClearPage) {
+      hasNavigatedToClearPage = true;
+      goToClearPage();
+    }
+    return;
   }
-  if (!goalReached) {
-    hasGoalAlerted = false;
-  }
+
+  hasNavigatedToClearPage = false;
 };
 
 drawMaze();

--- a/pc-clear.html
+++ b/pc-clear.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PC - クリア</title>
+    <link rel="stylesheet" href="css/styles.css" />
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+    <script src="js/navigation-endpoint.js" defer></script>
+    <script src="js/pc-clear.js" defer></script>
+  </head>
+  <body class="page page-pc-clear">
+    <main>
+      <h1>クリアおめでとうございます！</h1>
+      <p class="code-display" data-code-display></p>
+      <p class="clear-message">
+        問題をクリアしました。ほかの問題にも挑戦してみましょう。
+      </p>
+      <div class="page-footer">
+        <a class="back-button" data-back-button href="pc-problem.html">問題選択に戻る</a>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated clear screen that users are redirected to after finishing a maze
- provide styling and behaviour so the clear screen shows the connection code and a button back to the problem list
- update PC maze flows to navigate to the clear screen instead of showing alerts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00ffcdb9483299fc111dba083d297