### PR TITLE
Add success navigation for mobile password puzzles

### DIFF
--- a/js/mobile-problem3.js
+++ b/js/mobile-problem3.js
@@ -13,6 +13,15 @@
 
   const fallbackPassword = 'SHADOW-ACCESS';
   const password = (main?.dataset?.password || '').trim() || fallbackPassword;
+  const successUrl = (main?.dataset?.successUrl || '').trim();
+  let hasNavigatedToSuccess = false;
+
+  const navigateToSuccess = () => {
+    if (!successUrl || hasNavigatedToSuccess) return;
+    hasNavigatedToSuccess = true;
+    const url = code ? `${successUrl}?code=${encodeURIComponent(code)}` : successUrl;
+    window.location.replace(url);
+  };
 
   if (codeDisplay) {
     codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
@@ -273,6 +282,7 @@
 
       if (value.toUpperCase() === password.toUpperCase()) {
         setFeedbackMessage('正解です！PC側で背景が暗くなるとパスワードが現れます。');
+        navigateToSuccess();
       } else {
         setFeedbackMessage('パスワードが一致しません。PC画面をもう一度確認してください。');
       }

--- a/js/mobile-problem4.js
+++ b/js/mobile-problem4.js
@@ -25,6 +25,15 @@
 
   const fallbackPassword = 'NAVIGATOR';
   const password = (main?.dataset?.password || '').trim() || fallbackPassword;
+  const successUrl = (main?.dataset?.successUrl || '').trim();
+  let hasNavigatedToSuccess = false;
+
+  const navigateToSuccess = () => {
+    if (!successUrl || hasNavigatedToSuccess) return;
+    hasNavigatedToSuccess = true;
+    const url = code ? `${successUrl}?code=${encodeURIComponent(code)}` : successUrl;
+    window.location.replace(url);
+  };
 
   if (codeDisplay) {
     codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
@@ -396,6 +405,7 @@
 
       if (value.toUpperCase() === password.toUpperCase()) {
         setFeedbackMessage('正解です！PC画面に表示された断片を順番に並べられました。');
+        navigateToSuccess();
       } else {
         setFeedbackMessage('パスワードが一致しません。断片の順番をもう一度確認してください。');
       }

--- a/js/mobile-problem5.js
+++ b/js/mobile-problem5.js
@@ -71,6 +71,15 @@
 
   const fallbackPassword = 'ECHO-VOICE';
   const password = (main?.dataset?.password || '').trim() || fallbackPassword;
+  const successUrl = (main?.dataset?.successUrl || '').trim();
+  let hasNavigatedToSuccess = false;
+
+  const navigateToSuccess = () => {
+    if (!successUrl || hasNavigatedToSuccess) return;
+    hasNavigatedToSuccess = true;
+    const url = code ? `${successUrl}?code=${encodeURIComponent(code)}` : successUrl;
+    window.location.replace(url);
+  };
 
   if (codeDisplay) {
     codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
@@ -336,6 +345,7 @@
 
       if (value.toUpperCase() === password.toUpperCase()) {
         setFeedbackMessage('正解です！PC画面の指示を確認しましょう。');
+        navigateToSuccess();
       } else {
         setFeedbackMessage('パスワードが一致しません。もう一度PC側を確認してください。');
       }

--- a/js/mobile-problem6.js
+++ b/js/mobile-problem6.js
@@ -85,6 +85,15 @@
 
   const fallbackPassword = 'RHYTHM-RISE';
   const password = (main?.dataset?.password || '').trim() || fallbackPassword;
+  const successUrl = (main?.dataset?.successUrl || '').trim();
+  let hasNavigatedToSuccess = false;
+
+  const navigateToSuccess = () => {
+    if (!successUrl || hasNavigatedToSuccess) return;
+    hasNavigatedToSuccess = true;
+    const url = code ? `${successUrl}?code=${encodeURIComponent(code)}` : successUrl;
+    window.location.replace(url);
+  };
 
   if (codeDisplay) {
     codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
@@ -325,6 +334,7 @@
 
       if (value.toUpperCase() === password.toUpperCase()) {
         setFeedbackMessage('正解です！PC側の画面を確認しましょう。');
+        navigateToSuccess();
       } else {
         setFeedbackMessage('パスワードが一致しません。PC画面を再確認してください。');
       }

--- a/mobile-problem3.html
+++ b/mobile-problem3.html
@@ -9,7 +9,7 @@
     <script src="js/mobile-problem3.js" defer></script>
   </head>
   <body class="page page-mobile-problem3">
-    <main data-password="SHADOW-ACCESS">
+    <main data-password="SHADOW-ACCESS" data-success-url="mobile-next.html">
       <h1>問題3: 光と影のパスワード</h1>
       <p class="code-display" data-code-display></p>
       <p class="status" data-status>カメラを同期すると背景が変化します。</p>

--- a/mobile-problem4.html
+++ b/mobile-problem4.html
@@ -9,7 +9,7 @@
     <script src="js/mobile-problem4.js" defer></script>
   </head>
   <body class="page page-mobile-problem4">
-    <main data-password="NAVIGATOR">
+    <main data-password="NAVIGATOR" data-success-url="mobile-next.html">
       <h1>問題4: 方位のキーワード</h1>
       <p class="code-display" data-code-display></p>
       <p class="instruction">

--- a/mobile-problem5.html
+++ b/mobile-problem5.html
@@ -10,7 +10,7 @@
     <script src="js/mobile-problem5.js" defer></script>
   </head>
   <body class="page page-mobile-problem5">
-    <main data-password="ECHO-VOICE">
+    <main data-password="ECHO-VOICE" data-success-url="mobile-next.html">
       <h1>問題5: 音の共鳴</h1>
       <p class="code-display" data-code-display></p>
       <p class="instruction">

--- a/mobile-problem6.html
+++ b/mobile-problem6.html
@@ -10,7 +10,7 @@
     <script src="js/mobile-problem6.js" defer></script>
   </head>
   <body class="page page-mobile-problem6">
-    <main data-password="RHYTHM-RISE">
+    <main data-password="RHYTHM-RISE" data-success-url="mobile-next.html">
       <h1>問題6: シェイクカウント</h1>
       <p class="code-display" data-code-display></p>
       <p class="instruction">


### PR DESCRIPTION
## Summary
- add configurable success URLs to the mobile password puzzle pages
- redirect the mobile client to the success page once the correct password is submitted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e015c2a8d083299d8b14df55665f0a