### PR TITLE
Fix clear screen back navigation buttons

### DIFF
--- a/js/mobile-clear.js
+++ b/js/mobile-clear.js
@@ -2,8 +2,7 @@
   const params = new URLSearchParams(window.location.search);
   const code = (params.get('code') || '').trim();
   const codeDisplay = document.querySelector('[data-code-display]');
-  const pcButton = document.querySelector('[data-pc-button]');
-  const mobileBackButton = document.querySelector('[data-mobile-back-button]');
+  const backButton = document.querySelector('[data-back-button]');
 
   const buildDestination = (baseUrl) =>
     code ? `${baseUrl}?code=${encodeURIComponent(code)}` : baseUrl;
@@ -12,12 +11,8 @@
     codeDisplay.textContent = code ? `接続コード: ${code}` : '接続コード未取得';
   }
 
-  if (pcButton) {
-    pcButton.setAttribute('href', buildDestination('pc-problem.html'));
-  }
-
-  if (mobileBackButton) {
-    mobileBackButton.setAttribute('href', buildDestination('mobile-problem.html'));
+  if (backButton) {
+    backButton.setAttribute('href', buildDestination('mobile-problem.html'));
   }
 
   const resolveNavigationEndpoint = () => {
@@ -87,8 +82,8 @@
 
   setupBackNavigation();
 
-  if (mobileBackButton) {
-    mobileBackButton.addEventListener('click', (event) => {
+  if (backButton) {
+    backButton.addEventListener('click', (event) => {
       event.preventDefault();
       notifyBackNavigation();
       goToWaitScreen();

--- a/js/pc-clear.js
+++ b/js/pc-clear.js
@@ -3,7 +3,6 @@
   const code = params.get('code') || '';
   const codeDisplay = document.querySelector('[data-code-display]');
   const backButton = document.querySelector('[data-back-button]');
-  const mobileWaitButton = document.querySelector('[data-mobile-wait-button]');
 
   const buildDestination = (baseUrl) =>
     code ? `${baseUrl}?code=${encodeURIComponent(code)}` : baseUrl;
@@ -14,10 +13,6 @@
 
   if (backButton) {
     backButton.setAttribute('href', buildDestination('pc-problem.html'));
-  }
-
-  if (mobileWaitButton) {
-    mobileWaitButton.setAttribute('href', buildDestination('mobile-problem.html'));
   }
 
   const resolveNavigationEndpoint = () => {
@@ -91,12 +86,6 @@
       event.preventDefault();
       notifyBackNavigation();
       goBackToProblem();
-    });
-  }
-
-  if (mobileWaitButton) {
-    mobileWaitButton.addEventListener('click', () => {
-      notifyBackNavigation();
     });
   }
 

--- a/mobile-clear.html
+++ b/mobile-clear.html
@@ -13,11 +13,10 @@
       <h1>クリアおめでとうございます！</h1>
       <p class="code-display" data-code-display></p>
       <p class="clear-message">
-        PC側にもクリア画面が表示されました。次に進む操作を選んでください。
+        PC側にもクリア画面が表示されました。戻るボタンを押すとPCとスマホが同時に待機画面へ戻ります。
       </p>
       <div class="clear-actions">
-        <a class="clear-action-button" data-pc-button href="pc-problem.html">PCで問題選択に戻る</a>
-        <a class="clear-action-button secondary" data-mobile-back-button href="mobile-problem.html">スマホ待機画面に戻る</a>
+        <a class="clear-action-button" data-back-button href="mobile-problem.html">待機画面に戻る</a>
       </div>
     </main>
   </body>

--- a/pc-clear.html
+++ b/pc-clear.html
@@ -13,11 +13,10 @@
       <h1>クリアおめでとうございます！</h1>
       <p class="code-display" data-code-display></p>
       <p class="clear-message">
-        問題をクリアしました。ほかの問題にも挑戦してみましょう。
+        問題をクリアしました。戻るボタンを押すとPCとスマホが同時に待機画面へ戻ります。
       </p>
       <div class="clear-actions">
-        <a class="clear-action-button" data-back-button href="pc-problem.html">PCで問題選択に戻る</a>
-        <a class="clear-action-button secondary" data-mobile-wait-button href="mobile-problem.html">スマホ待機画面に戻る</a>
+        <a class="clear-action-button" data-back-button href="pc-problem.html">問題選択画面に戻る</a>
       </div>
     </main>
   </body>

--- a/server.js
+++ b/server.js
@@ -318,8 +318,9 @@ io.on('connection', (socket) => {
     if (!code || code.length !== CODE_LEN) return;
     const role = typeof payload.role === 'string' ? payload.role : undefined;
     roomStates.set(code, { step:'problemSelection' });
-    const notifyPayload = { room:code, code }; if (role) notifyPayload.from = role;
-    socket.to(code).emit('navigateBack', notifyPayload);
+    const notifyPayload = { room:code, code };
+    if (role) notifyPayload.from = role;
+    io.to(code).emit('navigateBack', notifyPayload);
     io.to(code).emit('status', { room:code, code, step:'problemSelection', from: role });
   });
 


### PR DESCRIPTION
## Summary
- remove redundant clear screen buttons so each device shows a single shared back control
- ensure clear screen messaging reflects synchronized navigation
- simplify clear screen scripts to match the new back button behaviour
- broadcast navigateBack events from the server so both clients are synchronized when returning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0266d86248329a4ef6d6133c3cc21