### PR TITLE
Ensure solved rooms point to clear destinations

### DIFF
--- a/js/mobile-clear.js
+++ b/js/mobile-clear.js
@@ -28,17 +28,31 @@
     withCredentials: true,
   });
 
+  let hasNotifiedProblemSolved = false;
+
   const joinRoom = () => {
     if (!code) return;
     navigationSocket.emit('join', { room: code, role: 'mobile' });
   };
 
-  if (navigationSocket.connected) {
+  const notifyProblemSolved = () => {
+    if (!code) return;
+    if (hasNotifiedProblemSolved) return;
+    hasNotifiedProblemSolved = true;
+    navigationSocket.emit('problemSolved', { room: code, role: 'mobile' });
+  };
+
+  const handleConnection = () => {
     joinRoom();
+    notifyProblemSolved();
+  };
+
+  if (navigationSocket.connected) {
+    handleConnection();
   }
 
-  navigationSocket.on('connect', joinRoom);
-  navigationSocket.on('reconnect', joinRoom);
+  navigationSocket.on('connect', handleConnection);
+  navigationSocket.on('reconnect', handleConnection);
 
   const notifyBackNavigation = () => {
     if (!code) return;

--- a/server.js
+++ b/server.js
@@ -211,6 +211,13 @@ const emitMazeState = (target, room, mazeState, {direction, moved, goalReached, 
   target.emit('mazeState', payload);
 };
 
+const SOLVED_DESTINATIONS = Object.freeze({
+  pc: 'pc-clear.html',
+  mobile: 'mobile-clear.html',
+});
+
+const cloneSolvedDestinations = () => ({ ...SOLVED_DESTINATIONS });
+
 const markProblemSolved = (code, { emitterRole, solvedAt } = {}) => {
   const room = sanitizeCode(code);
   if (!room || room.length !== CODE_LEN) return;
@@ -224,14 +231,17 @@ const markProblemSolved = (code, { emitterRole, solvedAt } = {}) => {
   if (emitterRole) {
     state.lastSolvedBy = emitterRole;
   }
+  state.destinations = cloneSolvedDestinations();
   roomStates.set(room, state);
 
-  const problemSolvedPayload = { room, code: room };
+  const destinations = cloneSolvedDestinations();
+
+  const problemSolvedPayload = { room, code: room, destinations };
   if (emitterRole) {
     problemSolvedPayload.from = emitterRole;
   }
 
-  const statusPayload = { room, code: room, ...state, step: 'problemSolved' };
+  const statusPayload = { room, code: room, ...state, step: 'problemSolved', destinations };
   if (emitterRole) {
     statusPayload.from = emitterRole;
   }


### PR DESCRIPTION
## Summary
- update the server's solved-state handling to broadcast the clear page destinations to connected clients

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e03d0d91f08329b6696f5e4b420aa0