### PR TITLE
ジャイロ迷路の正解時遷移を安定化

### DIFF
--- a/mobile-gyro.html
+++ b/mobile-gyro.html
@@ -6,10 +6,11 @@
     <link rel="stylesheet" href="css/styles.css" />
     <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
     <script src="js/navigation-endpoint.js" defer></script>
+    <script src="js/password-success.js" defer></script>
     <script src="js/mobile-gyro.js" defer></script>
   </head>
   <body class="page page-mobile-controller page-mobile-gyro">
-    <main>
+    <main data-success-url="mobile-clear.html">
       <h1>スマホを傾けて迷路を進もう</h1>
       <p class="code-display" data-code-display></p>
       <p class="controller-status" data-status aria-live="polite"></p>

--- a/pc-gyro.html
+++ b/pc-gyro.html
@@ -7,16 +7,19 @@
     <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
     <script src="js/maze-logic.js" defer></script>
     <script src="js/navigation-endpoint.js" defer></script>
+    <script src="js/password-success.js" defer></script>
     <script src="js/pc-gyro.js" defer></script>
   </head>
   <body class="page page-pc-maze page-pc-gyro">
-    <h1>ジャイロ迷路</h1>
-    <p class="maze-description">
-      スマホを傾けてキャラクターをゴールまで導いてください。PC側では迷路の様子がリアルタイムで表示されます。
-    </p>
-    <div id="maze" aria-live="polite"></div>
-    <div class="page-footer">
-      <a class="back-button" href="pc-problem.html">問題に戻る</a>
-    </div>
+    <main data-success-url="pc-clear.html">
+      <h1>ジャイロ迷路</h1>
+      <p class="maze-description">
+        スマホを傾けてキャラクターをゴールまで導いてください。PC側では迷路の様子がリアルタイムで表示されます。
+      </p>
+      <div id="maze" aria-live="polite"></div>
+      <div class="page-footer">
+        <a class="back-button" href="pc-problem.html">問題に戻る</a>
+      </div>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- スマホとPCのジャイロ迷路ページに成功時の遷移先指定とPasswordSuccessナビゲーターを導入し、接続コード付きで適切な画面へ移動できるようにしました
- サーバーから配信される遷移情報を反映し、正解通知を受け取ったときに常に指定ページへ遷移するようクライアントのハンドリングを強化しました

## Testing
- node --test tests/*.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e041d8b4608329aff7f9a0cc49d2d8