### PR TITLE
モバイルUIのフォントとボタンサイズを拡大

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,3 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap");
+
 @keyframes gradientFlow {
   0% {
     background-position: 0% 50%;
@@ -42,7 +44,7 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Noto Sans JP", sans-serif;
   line-height: 1.5;
   background: linear-gradient(135deg, #ff6ec4, #7873f5, #4ac29a, #fbe29f);
   background-size: 320% 320%;
@@ -154,24 +156,31 @@ body {
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 1.5rem;
+      gap: 1.8rem;
       min-height: calc(100vh - 8rem);
 
+      h1 {
+        margin: 0;
+        text-align: center;
+        font-size: clamp(1.8rem, 6vw, 2.6rem);
+        font-weight: 700;
+      }
+
       #mobileCodeInput {
-        font-size: 2rem;
-        padding: 0.8rem 1.5rem;
-        border-radius: 0.7rem;
+        font-size: clamp(2.2rem, 7vw, 3rem);
+        padding: 1.1rem 1.8rem;
+        border-radius: 0.9rem;
         border: 1px solid #ccc;
         text-align: center;
-        width: 220px;
+        width: min(280px, 82vw);
         max-width: 90vw;
         letter-spacing: 0.2em;
       }
 
       button.js-connect {
-        font-size: 1.3rem;
-        padding: 0.8rem 2.5rem;
-        border-radius: 0.7rem;
+        font-size: clamp(1.5rem, 5vw, 2rem);
+        padding: 1.1rem 3rem;
+        border-radius: 1.1rem;
         border: none;
         background: #4caf50;
         color: #fff;
@@ -286,17 +295,22 @@ body {
       width: min(520px, 90vw);
       background: #ffffff;
       border-radius: 1.5rem;
-      padding: 3rem 2.5rem;
+      padding: 3.4rem 2.8rem;
       box-shadow: 0 10px 28px rgba(0, 0, 0, 0.1);
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 1.5rem;
+      gap: 1.8rem;
       text-align: center;
+      h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 6vw, 2.6rem);
+        font-weight: 700;
+      }
     }
 
     .code-display {
-      font-size: 1.4rem;
+      font-size: clamp(1.6rem, 5.5vw, 2.1rem);
       font-weight: 700;
       letter-spacing: 0.08em;
       margin: 0;
@@ -305,6 +319,8 @@ body {
     .wait-instruction {
       margin: 0;
       color: #555;
+      font-size: clamp(1.1rem, 4.5vw, 1.5rem);
+      line-height: 1.75;
     }
 
     .wait-indicator {
@@ -313,8 +329,8 @@ body {
       margin-top: 1rem;
 
       span {
-        width: 0.9rem;
-        height: 0.9rem;
+        width: 1.1rem;
+        height: 1.1rem;
         border-radius: 50%;
         background: #355cdd;
         opacity: 0.3;
@@ -341,6 +357,9 @@ body {
 
     h1 {
       margin: 0;
+      font-size: clamp(1.8rem, 6vw, 2.6rem);
+      font-weight: 700;
+      text-align: center;
     }
 
     .controller {
@@ -348,13 +367,13 @@ body {
       grid-template-areas:
         ". up ."
         "left down right";
-      gap: 1rem;
+      gap: 1.2rem;
       width: min(480px, 90vw);
 
       button {
-        font-size: clamp(3rem, 12vw, 5rem);
-        padding: 1.5rem;
-        border-radius: 1rem;
+        font-size: clamp(3.4rem, 12vw, 5.6rem);
+        padding: clamp(1.6rem, 6vw, 2.2rem);
+        border-radius: 1.2rem;
         border: none;
         background: #355cdd;
         color: #fff;
@@ -392,6 +411,8 @@ body {
       color: #355cdd;
       font-weight: 600;
       text-align: center;
+      font-size: clamp(1.2rem, 4.5vw, 1.6rem);
+      line-height: 1.6;
     }
   }
 
@@ -654,16 +675,16 @@ body {
       width: min(520px, 92vw);
       background: #ffffff;
       border-radius: 1.5rem;
-      padding: 2.5rem 2rem 3rem;
+      padding: 2.8rem 2.2rem 3.2rem;
       box-shadow: 0 14px 32px rgba(0, 0, 0, 0.08);
       display: flex;
       flex-direction: column;
-      gap: 1.5rem;
+      gap: 1.7rem;
     }
 
     h1 {
       margin: 0;
-      font-size: clamp(1.4rem, 4vw, 1.8rem);
+      font-size: clamp(1.8rem, 5.5vw, 2.4rem);
       text-align: center;
     }
 
@@ -672,6 +693,7 @@ body {
       font-weight: 700;
       letter-spacing: 0.1em;
       text-align: center;
+      font-size: clamp(1.4rem, 5vw, 1.9rem);
     }
 
     .status {
@@ -680,16 +702,17 @@ body {
       color: #355cdd;
       font-weight: 600;
       text-align: center;
+      font-size: clamp(1.2rem, 4.5vw, 1.6rem);
     }
 
     .camera-button {
       align-self: center;
-      padding: 0.9rem 2.6rem;
+      padding: 1.1rem 3rem;
       border-radius: 999px;
       border: none;
       background: #355cdd;
       color: #fff;
-      font-size: 1.1rem;
+      font-size: clamp(1.3rem, 4.5vw, 1.7rem);
       font-weight: 700;
       cursor: pointer;
       box-shadow: 0 10px 24px rgba(53, 92, 221, 0.28);
@@ -726,16 +749,17 @@ body {
     .password-form {
       display: flex;
       flex-direction: column;
-      gap: 0.7rem;
+      gap: 0.8rem;
 
       label {
         font-weight: 600;
+        font-size: clamp(1.1rem, 4vw, 1.4rem);
       }
 
       input {
-        font-size: 1.2rem;
-        padding: 0.75rem 1rem;
-        border-radius: 0.8rem;
+        font-size: clamp(1.3rem, 4.5vw, 1.6rem);
+        padding: 0.9rem 1.2rem;
+        border-radius: 0.95rem;
         border: 1px solid #cdd6f7;
         letter-spacing: 0.12em;
         text-transform: uppercase;
@@ -743,8 +767,8 @@ body {
 
       button {
         align-self: flex-end;
-        padding: 0.6rem 1.6rem;
-        border-radius: 0.8rem;
+        padding: 0.8rem 1.9rem;
+        border-radius: 0.95rem;
         border: none;
         background: #43a047;
         color: #fff;
@@ -771,6 +795,7 @@ body {
       font-weight: 600;
       color: #333;
       text-align: center;
+      font-size: clamp(1.1rem, 4.5vw, 1.5rem);
     }
 
     .page-footer {
@@ -791,16 +816,16 @@ body {
       width: min(520px, 92vw);
       background: #ffffff;
       border-radius: 1.5rem;
-      padding: 2.5rem 2rem 3rem;
+      padding: 2.8rem 2.2rem 3.2rem;
       box-shadow: 0 16px 36px rgba(29, 56, 119, 0.12);
       display: flex;
       flex-direction: column;
-      gap: 1.4rem;
+      gap: 1.6rem;
     }
 
     h1 {
       margin: 0;
-      font-size: clamp(1.4rem, 4vw, 1.8rem);
+      font-size: clamp(1.8rem, 5.5vw, 2.4rem);
       text-align: center;
     }
 
@@ -810,24 +835,25 @@ body {
       letter-spacing: 0.08em;
       text-align: center;
       color: #2b4a9e;
+      font-size: clamp(1.4rem, 5vw, 1.9rem);
     }
 
     .instruction {
       margin: 0;
       line-height: 1.6;
-      font-size: 0.95rem;
+      font-size: clamp(1.1rem, 4.2vw, 1.5rem);
       color: #3a4a6a;
     }
 
     .compass-button {
       align-self: center;
-      padding: 0.85rem 2.4rem;
+      padding: 1.1rem 2.8rem;
       border-radius: 999px;
       border: none;
       background: #2b4a9e;
       color: #fff;
       font-weight: 700;
-      font-size: 1.05rem;
+      font-size: clamp(1.3rem, 4.5vw, 1.7rem);
       cursor: pointer;
       box-shadow: 0 12px 24px rgba(43, 74, 158, 0.24);
       transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
@@ -852,6 +878,7 @@ body {
       color: #1b3a84;
       font-weight: 600;
       text-align: center;
+      font-size: clamp(1.2rem, 4.5vw, 1.6rem);
     }
 
     .heading-display,
@@ -860,6 +887,7 @@ body {
       text-align: center;
       font-weight: 600;
       color: #324066;
+      font-size: clamp(1.1rem, 4.2vw, 1.5rem);
     }
 
     .compass-progress {
@@ -870,12 +898,13 @@ body {
       gap: 0.5rem;
 
       li {
-        padding: 0.6rem 0.8rem;
-        border-radius: 0.75rem;
+        padding: 0.75rem 1rem;
+        border-radius: 0.9rem;
         background: #f1f5ff;
         color: #2f4169;
         font-weight: 600;
         text-align: center;
+        font-size: clamp(1.05rem, 4vw, 1.4rem);
         transition: background 0.2s ease, color 0.2s ease;
 
         &.is-complete {
@@ -888,24 +917,25 @@ body {
     .password-form {
       display: flex;
       flex-direction: column;
-      gap: 0.75rem;
+      gap: 0.8rem;
     }
 
     .password-form label {
       font-weight: 600;
       color: #21325a;
+      font-size: clamp(1.1rem, 4vw, 1.4rem);
     }
 
     .password-form input {
-      padding: 0.75rem 1rem;
-      border-radius: 0.75rem;
+      padding: 0.9rem 1.2rem;
+      border-radius: 0.95rem;
       border: 1px solid #c5d3f2;
-      font-size: 1rem;
-      letter-spacing: 0.05em;
+      font-size: clamp(1.25rem, 4.2vw, 1.6rem);
+      letter-spacing: 0.08em;
     }
 
     .password-form button {
-      padding: 0.7rem 1.2rem;
+      padding: 0.85rem 1.8rem;
       border-radius: 999px;
       border: none;
       background: #2b4a9e;
@@ -913,11 +943,12 @@ body {
       font-weight: 700;
       cursor: pointer;
       align-self: flex-end;
+      font-size: clamp(1.2rem, 4.2vw, 1.5rem);
     }
 
     .password-hint {
       margin: 0;
-      font-size: 0.85rem;
+      font-size: clamp(1rem, 3.6vw, 1.3rem);
       color: #5a6a8e;
     }
 
@@ -927,6 +958,7 @@ body {
       color: #2b4a9e;
       font-weight: 600;
       text-align: center;
+      font-size: clamp(1.1rem, 4.5vw, 1.5rem);
     }
 
     .page-footer {
@@ -946,17 +978,17 @@ body {
       width: min(520px, 92vw);
       background: #ffffff;
       border-radius: 1.5rem;
-      padding: 2.5rem 2rem 3rem;
+      padding: 2.8rem 2.2rem 3.2rem;
       box-shadow: 0 18px 42px rgba(31, 56, 117, 0.15);
       display: flex;
       flex-direction: column;
-      gap: 1.4rem;
+      gap: 1.6rem;
     }
 
     h1 {
       margin: 0;
       text-align: center;
-      font-size: clamp(1.4rem, 4vw, 1.9rem);
+      font-size: clamp(1.8rem, 5.5vw, 2.5rem);
     }
 
     .code-display {
@@ -965,12 +997,13 @@ body {
       font-weight: 700;
       letter-spacing: 0.08em;
       color: #2b4a9e;
+      font-size: clamp(1.4rem, 5vw, 1.9rem);
     }
 
     .instruction {
       margin: 0;
       line-height: 1.6;
-      font-size: 0.95rem;
+      font-size: clamp(1.1rem, 4.2vw, 1.5rem);
       color: #3a4a6a;
     }
 
@@ -979,13 +1012,14 @@ body {
       font-weight: 600;
       color: #2b4a9e;
       text-align: center;
+      font-size: clamp(1.2rem, 4.5vw, 1.6rem);
     }
 
     .level-indicator,
     .shake-bar {
       position: relative;
       width: 100%;
-      height: 0.9rem;
+      height: 1.1rem;
       border-radius: 999px;
       background: rgba(43, 74, 158, 0.15);
       overflow: hidden;
@@ -1008,18 +1042,19 @@ body {
       text-align: center;
       font-weight: 600;
       color: #2b4a9e;
+      font-size: clamp(1.1rem, 4.2vw, 1.5rem);
     }
 
     .mic-button,
     .shake-button {
       align-self: center;
-      padding: 0.85rem 2.6rem;
+      padding: 1.1rem 3rem;
       border-radius: 999px;
       border: none;
       background: #2b4a9e;
       color: #fff;
       font-weight: 700;
-      font-size: 1.05rem;
+      font-size: clamp(1.3rem, 4.5vw, 1.7rem);
       cursor: pointer;
       box-shadow: 0 14px 28px rgba(43, 74, 158, 0.22);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -1045,12 +1080,13 @@ body {
 
       label {
         font-weight: 600;
+        font-size: clamp(1.1rem, 4vw, 1.4rem);
       }
 
       input {
-        font-size: 1.1rem;
-        padding: 0.75rem 1rem;
-        border-radius: 0.9rem;
+        font-size: clamp(1.3rem, 4.5vw, 1.6rem);
+        padding: 0.9rem 1.2rem;
+        border-radius: 1rem;
         border: 1px solid #c9d4f5;
         letter-spacing: 0.12em;
         text-transform: uppercase;
@@ -1058,8 +1094,8 @@ body {
 
       button {
         align-self: flex-end;
-        padding: 0.6rem 1.6rem;
-        border-radius: 0.9rem;
+        padding: 0.8rem 1.9rem;
+        border-radius: 1rem;
         border: none;
         background: #43a047;
         color: #fff;
@@ -1082,7 +1118,7 @@ body {
 
     .password-hint {
       margin: 0;
-      font-size: 0.85rem;
+      font-size: clamp(1rem, 3.6vw, 1.3rem);
       color: #5a6a8e;
     }
 
@@ -1092,10 +1128,11 @@ body {
       color: #2b4a9e;
       font-weight: 600;
       text-align: center;
+      font-size: clamp(1.1rem, 4.5vw, 1.5rem);
     }
 
     .page-footer {
-      margin-top: 1.2rem;
+      margin-top: 1.4rem;
     }
   }
 


### PR DESCRIPTION
## 概要
- Google FontsのNoto Sans JPを読み込み、全体の基本フォントを統一しました
- スマホ向け各画面の見出し・入力欄・ボタン・ステータスメッセージのサイズを拡大し、視認性とタップしやすさを改善しました

## テスト
- 未実施（UI変更のため）

------
https://chatgpt.com/codex/tasks/task_e_68e13ccb28c483299cc4826b9b3aab5e