### PR TITLE
モバイル端末でコンパス・マイク・シェイクを自動開始

### DIFF
--- a/js/mobile-problem4.js
+++ b/js/mobile-problem4.js
@@ -375,6 +375,33 @@
     });
   }
 
+  const scheduleAutoStart = () => {
+    const attemptStart = () => {
+      startCompass();
+    };
+
+    const visibility = document.visibilityState;
+    if (typeof visibility !== 'string' || visibility === 'visible') {
+      attemptStart();
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        attemptStart();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange, { once: true });
+  };
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    scheduleAutoStart();
+  } else {
+    window.addEventListener('load', scheduleAutoStart, { once: true });
+  }
+
   window.addEventListener('beforeunload', () => {
     stopCompass();
   });

--- a/js/mobile-problem5.js
+++ b/js/mobile-problem5.js
@@ -318,6 +318,33 @@
     });
   }
 
+  const scheduleAutoStart = () => {
+    const attemptStart = () => {
+      startMicrophone();
+    };
+
+    const visibility = document.visibilityState;
+    if (typeof visibility !== 'string' || visibility === 'visible') {
+      attemptStart();
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        attemptStart();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange, { once: true });
+  };
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    scheduleAutoStart();
+  } else {
+    window.addEventListener('load', scheduleAutoStart, { once: true });
+  }
+
   window.addEventListener('beforeunload', stopMicrophone);
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {

--- a/js/mobile-problem6.js
+++ b/js/mobile-problem6.js
@@ -307,6 +307,33 @@
     });
   }
 
+  const scheduleAutoStart = () => {
+    const attemptStart = () => {
+      startMonitoring();
+    };
+
+    const visibility = document.visibilityState;
+    if (typeof visibility !== 'string' || visibility === 'visible') {
+      attemptStart();
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        attemptStart();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange, { once: true });
+  };
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    scheduleAutoStart();
+  } else {
+    window.addEventListener('load', scheduleAutoStart, { once: true });
+  }
+
   window.addEventListener('beforeunload', stopMonitoring);
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {


### PR DESCRIPTION
## 概要
- コンパス計測をページ読み込み時に自動開始するフローを追加
- マイク計測をページ読み込み時に自動開始するフローを追加
- シェイク計測をページ読み込み時に自動開始するフローを追加

## テスト
- テスト未実施


------
https://chatgpt.com/codex/tasks/task_e_68e1546b44008329827fecb63f6750d3